### PR TITLE
Add CGO wrappers and tests for Clipper2 port

### DIFF
--- a/capi/clipper_cgo_test.go
+++ b/capi/clipper_cgo_test.go
@@ -7,7 +7,7 @@ import "testing"
 func TestUnionTiny(t *testing.T) {
 	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
 	b := Paths64{{{5, 5}, {15, 5}, {15, 15}, {5, 15}}}
-	got, open, err := BooleanOp64(/*Union*/ 1, /*NonZero*/ 1, a, nil, b)
+	got, open, err := BooleanOp64( /*Union*/ 1 /*NonZero*/, 1, a, nil, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func TestUnionTiny(t *testing.T) {
 func TestIntersectionTiny(t *testing.T) {
 	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
 	b := Paths64{{{5, 5}, {15, 5}, {15, 15}, {5, 15}}}
-	got, open, err := BooleanOp64(/*Intersection*/ 0, /*NonZero*/ 1, a, nil, b)
+	got, open, err := BooleanOp64( /*Intersection*/ 0 /*NonZero*/, 1, a, nil, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestIntersectionTiny(t *testing.T) {
 func TestDifferenceTiny(t *testing.T) {
 	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
 	b := Paths64{{{5, 5}, {15, 5}, {15, 15}, {5, 15}}}
-	got, open, err := BooleanOp64(/*Difference*/ 2, /*NonZero*/ 1, a, nil, b)
+	got, open, err := BooleanOp64( /*Difference*/ 2 /*NonZero*/, 1, a, nil, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestDifferenceTiny(t *testing.T) {
 func TestXorTiny(t *testing.T) {
 	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
 	b := Paths64{{{5, 5}, {15, 5}, {15, 15}, {5, 15}}}
-	got, open, err := BooleanOp64(/*Xor*/ 3, /*NonZero*/ 1, a, nil, b)
+	got, open, err := BooleanOp64( /*Xor*/ 3 /*NonZero*/, 1, a, nil, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,8 +71,8 @@ func TestXorTiny(t *testing.T) {
 func TestEmptyInputs(t *testing.T) {
 	empty := Paths64{}
 	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
-	
-	got, open, err := BooleanOp64(/*Union*/ 1, /*NonZero*/ 1, a, nil, empty)
+
+	got, open, err := BooleanOp64( /*Union*/ 1 /*NonZero*/, 1, a, nil, empty)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,4 +83,130 @@ func TestEmptyInputs(t *testing.T) {
 		t.Fatalf("expected 1 path for union with empty, got %d", len(got))
 	}
 	t.Logf("Union with empty result: %v", got)
+}
+
+func TestPackUnpackRoundTrip(t *testing.T) {
+	original := Paths64{
+		{{0, 0}, {10, 0}, {10, 10}, {0, 10}},
+		{{20, 20}, {30, 20}, {30, 30}, {20, 30}},
+	}
+	ptr, _, freeFn := packPaths64(original)
+	defer freeFn()
+	round := unpackPaths64(ptr)
+	if len(round) != len(original) {
+		t.Fatalf("round trip path count mismatch: got %d want %d", len(round), len(original))
+	}
+	for i := range original {
+		if len(round[i]) != len(original[i]) {
+			t.Fatalf("path %d length mismatch", i)
+		}
+		for j := range original[i] {
+			if round[i][j] != original[i][j] {
+				t.Fatalf("path %d point %d mismatch: got %v want %v", i, j, round[i][j], original[i][j])
+			}
+		}
+	}
+}
+
+func TestBooleanOp64OpenPaths(t *testing.T) {
+	subj := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
+	open := Paths64{{{0, 0}, {10, 10}}}
+	sol, solOpen, err := BooleanOp64( /*Union*/ 1 /*NonZero*/, 1, subj, open, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sol) != 1 {
+		t.Fatalf("expected 1 closed path, got %d", len(sol))
+	}
+	if len(solOpen) != 1 {
+		t.Fatalf("expected 1 open path, got %d", len(solOpen))
+	}
+	if len(solOpen[0]) != len(open[0]) {
+		t.Fatalf("open path length mismatch: got %d want %d", len(solOpen[0]), len(open[0]))
+	}
+	for i := range open[0] {
+		if solOpen[0][i] != open[0][i] {
+			t.Fatalf("open path point %d mismatch: got %v want %v", i, solOpen[0][i], open[0][i])
+		}
+	}
+}
+
+// area is a helper to calculate polygon signed area.
+func area(path Path64) int64 {
+	if len(path) < 3 {
+		return 0
+	}
+	sum := int64(0)
+	for i := 0; i < len(path); i++ {
+		j := (i + 1) % len(path)
+		sum += path[i].X*path[j].Y - path[j].X*path[i].Y
+	}
+	return sum / 2
+}
+
+func TestBooleanOp64WithHole(t *testing.T) {
+	outer := Path64{{0, 0}, {20, 0}, {20, 20}, {0, 20}}
+	hole := Path64{{15, 5}, {5, 5}, {5, 15}, {15, 15}}
+	subj := Paths64{outer, hole}
+	sol, open, err := BooleanOp64( /*Union*/ 1 /*NonZero*/, 1, subj, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("unexpected open paths")
+	}
+	if len(sol) != 2 {
+		t.Fatalf("expected 2 paths (outer+hole), got %d", len(sol))
+	}
+	// verify outer is positive orientation and hole negative
+	if area(sol[0])*area(sol[1]) > 0 {
+		t.Fatalf("expected opposite winding for outer and hole")
+	}
+}
+
+func TestBooleanOp64IntersectionCoords(t *testing.T) {
+	a := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
+	b := Paths64{{{5, 5}, {15, 5}, {15, 15}, {5, 15}}}
+	got, open, err := BooleanOp64( /*Intersection*/ 0 /*NonZero*/, 1, a, nil, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("unexpected open paths")
+	}
+	expect := Path64{{5, 5}, {10, 5}, {10, 10}, {5, 10}}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(got))
+	}
+	if len(got[0]) != len(expect) {
+		t.Fatalf("intersection vertex count mismatch: got %d want %d", len(got[0]), len(expect))
+	}
+	for i := range expect {
+		if got[0][i] != expect[i] {
+			t.Fatalf("vertex %d mismatch: got %v want %v", i, got[0][i], expect[i])
+		}
+	}
+}
+
+func TestInflatePaths64(t *testing.T) {
+	square := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
+	inflated, err := InflatePaths64(square, 2 /*Miter*/, 2 /*ClosedPolygon*/, 0, 2.0, 0.25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inflated) == 0 {
+		t.Fatalf("expected non-empty result from inflate")
+	}
+}
+
+func TestRectClip64(t *testing.T) {
+	rect := Path64{{0, 0}, {10, 0}, {10, 10}, {0, 10}}
+	paths := Paths64{{{-5, -5}, {5, -5}, {5, 5}, {-5, 5}}}
+	clipped, err := RectClip64(rect, paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(clipped) == 0 {
+		t.Fatalf("expected non-empty clipped result")
+	}
 }

--- a/port/clipper_test.go
+++ b/port/clipper_test.go
@@ -85,7 +85,7 @@ func TestArea64(t *testing.T) {
 	square := Path64{{0, 0}, {10, 0}, {10, 10}, {0, 10}}
 	area := Area64(square)
 	expected := 100.0
-	
+
 	if area != expected {
 		t.Errorf("Expected area %v, got %v", expected, area)
 	}
@@ -108,13 +108,13 @@ func TestIsPositive64(t *testing.T) {
 func TestReverse64(t *testing.T) {
 	original := Path64{{0, 0}, {10, 0}, {10, 10}, {0, 10}}
 	expected := Path64{{0, 10}, {10, 10}, {10, 0}, {0, 0}}
-	
+
 	result := Reverse64(original)
-	
+
 	if len(result) != len(expected) {
 		t.Fatalf("Length mismatch: expected %d, got %d", len(expected), len(result))
 	}
-	
+
 	for i, pt := range result {
 		if pt != expected[i] {
 			t.Errorf("Point %d: expected %v, got %v", i, expected[i], pt)
@@ -124,7 +124,7 @@ func TestReverse64(t *testing.T) {
 
 func TestInflatePaths64(t *testing.T) {
 	square := Paths64{{{0, 0}, {10, 0}, {10, 10}, {0, 10}}}
-	
+
 	result, err := InflatePaths64(square, 1.0, Round, ClosedPolygon)
 	if err == ErrNotImplemented {
 		t.Skip("InflatePaths64 not yet implemented")
@@ -132,9 +132,25 @@ func TestInflatePaths64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InflatePaths64 failed: %v", err)
 	}
-	
+
 	if len(result) == 0 {
 		t.Fatal("Expected non-empty result from inflate")
 	}
 	t.Logf("Inflate result: %v", result)
+}
+
+func TestRectClip64(t *testing.T) {
+	rect := Path64{{0, 0}, {10, 0}, {10, 10}, {0, 10}}
+	paths := Paths64{{{-5, -5}, {5, -5}, {5, 5}, {-5, 5}}}
+	result, err := RectClip64(rect, paths)
+	if err == ErrNotImplemented {
+		t.Skip("RectClip64 not yet implemented")
+	}
+	if err != nil {
+		t.Fatalf("RectClip64 failed: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("Expected non-empty result from rect clip")
+	}
+	t.Logf("RectClip result: %v", result)
 }


### PR DESCRIPTION
## Summary
- add CGO wrappers for InflatePaths64 and RectClip64 and expose helper for rectangular clipping
- expand CGO test suite with round-trip, open paths, holes, intersection coords, inflate and rect clip cases
- implement oracle-backed inflate and rect clip in Go port and add corresponding tests

## Testing
- `go test ./capi -tags=clipper_cgo` *(fails: Package 'Clipper2', required by 'virtual:world', not found)*
- `go test ./port`

------
https://chatgpt.com/codex/tasks/task_e_689a38ee9cf883218a1772170dc07e57